### PR TITLE
Add instructions for running under Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,55 @@ docker-compose build
 docker-compose up
 ```
 You will be able to inspect the logs. Once everything is working correctly, run the container with ``docker-compose up -d`` to run it in the background.
+
+## Running with Podman
+To avoid running with priveledged mode, podman can be used to build and run this image.
+
+The magic for avoiding prveledged is to add `--group-add keep-groups` to the `podman run` command. 
+
+This blog post explains it well: https://www.nite07.com/en/posts/podman-group-share/
+```sh
+podman build . -f Dockerfile -t localhost/map-reporter
+
+# Update the `-e DEVICE=` and `--device` lines below to match your meshcore
+# usb companion usb device path.
+podman run --restart=unless-stopped -d \
+  --device /dev/ttyUSB0:/dev/ttyUSB0 \
+  -e DEVICE=/dev/ttyUSB0 \
+  --group-add keep-groups \
+  --name meshcore-map-reporter \
+  localhost/map-reporter
+```
+
+### Persist reboots
+Since podman runs in the user context, it doesn't run a daemon by default like Docker does. To have your container start at boot time, we can leverage systemd to start podman at boot.
+
+See Also: https://www.redhat.com/en/blog/container-systemd-persist-reboot
+```sh
+# Use the container that we created in the previous step as a template to generate the systemd unit file.
+# No changes need to be made to the unit file
+podman generate systemd --new --files --name meshcore-map-reporter
+mkdir -p ~/.config/systemd/user/
+cp -Z container-meshcore-map-reporter.service ~/.config/systemd/user
+systemctl --user daemon-reload
+
+# Stop and remove the template container
+podman stop meshcore-map-reporter
+podman rm meshcore-map-reporter
+
+# Enable and start the container via systemd
+systemctl --user enable container-meshcore-map-reporter.service
+systemctl --user start container-meshcore-map-reporter.service
+```
+
+### View logs
+```sh
+journalctl --user -efu container-meshcore-map-reporter
+
+or
+
+podman logs -f meshcore-map-reporter
+```
+### Updating
+1. Build the container image with the same tag
+2. Restart the systemd service: `systemctl --user restart container-meshcore-map-reporter.service`


### PR DESCRIPTION
Podman allows for running containers without root permissions, and has features that allow us to avoid running this container with priveledged mode.